### PR TITLE
Add auto-save

### DIFF
--- a/.vscode/benoit.json
+++ b/.vscode/benoit.json
@@ -1,4 +1,5 @@
 {
     "window.zoomLevel": 2,
-    "workbench.colorTheme": "Default Light+"
+    "workbench.colorTheme": "Default Light+",
+    "files.autoSave": "onFocusChange"
 }

--- a/.vscode/gwendal.json
+++ b/.vscode/gwendal.json
@@ -1,4 +1,5 @@
 {
     "window.zoomLevel": 2,
-    "workbench.colorTheme": "Default Dark+"
+    "workbench.colorTheme": "Default Dark+",
+    "files.autoSave": "onFocusChange"
 }


### PR DESCRIPTION
To avoid forgetting to save while presenting.

onFocusChange saves when editor pane loses focus (switch to terminal, for example).